### PR TITLE
Fix: Correct redeclared variables in Tests.js test runner

### DIFF
--- a/elevateElement/components/tests/Tests.js
+++ b/elevateElement/components/tests/Tests.js
@@ -30,10 +30,6 @@ export async function testElevateElement(ElevateElement) {
     let totalTests = 0;
     let passedCount = 0;
 
-    console.log('[Test Runner] Starting test execution...');
-    let totalTests = 0;
-    let passedCount = 0;
-
     // Define all test elements by calling their builders
     // The ElevateElement parameter is passed to each builder.
     ErrorTestElementBuilder(ElevateElement);


### PR DESCRIPTION
Resolved a SyntaxError in `elevateElement/components/tests/Tests.js` where `totalTests` and `passedCount` variables were declared multiple times within the `testElevateElement` function.

Removed the duplicate declarations and a redundant console log message. This ensures the test runner function can execute without syntax errors, allowing the 'Run All Tests' functionality on the /tests page to operate as intended.