### PR TITLE
Fix(tests): Overhaul test suite and manual test page

### DIFF
--- a/elevateElement/components/builders/TestElement.js
+++ b/elevateElement/components/builders/TestElement.js
@@ -10,21 +10,111 @@ export function TestElementBuilder(ElevateElement) {
   class TestElement extends BaseComponent {
     constructor() {
       super('test-element');
-      this.status = 'OK';
+      this.state = {
+        currentStatus: 'OK',
+        testResult: { success: null, message: 'Test not run yet.' }
+      };
+
+      this._boundRunTest = this.runTest.bind(this);
+      this._boundTestAction = this.testAction.bind(this);
+    }
+
+    connectedCallback() {
+      super.connectedCallback();
+      console.log('[TestElement] connected');
+      // Initial render
+      if (typeof this.updateUI === 'function') {
+        this.updateUI();
+      } else if (typeof this.render === 'function' && this.shadowRoot) { // Assuming render is the template method name
+        this.shadowRoot.innerHTML = this.render();
+      } else if (typeof this.template === 'function' && this.shadowRoot) { // Fallback if template is used
+        this.shadowRoot.innerHTML = this.template();
+      }
+      this.attachEventHandlers();
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      console.log('[TestElement] disconnected');
+      this.removeEventListeners();
     }
 
     attachEventHandlers() {
-      BaseComponentUtils.attachEventHandlers(this, {
-        '.test-button': this.testAction
-      });
+      if (!this.shadowRoot) return;
+
+      const testButton = this.shadowRoot.querySelector('.test-button');
+      if (testButton) {
+        testButton.removeEventListener('click', this._boundTestAction);
+        testButton.addEventListener('click', this._boundTestAction);
+      }
+
+      const runTestButton = this.shadowRoot.querySelector('.run-this-test-button');
+      if (runTestButton) {
+        runTestButton.removeEventListener('click', this._boundRunTest);
+        runTestButton.addEventListener('click', this._boundRunTest);
+      }
+    }
+
+    removeEventListeners() {
+      if (!this.shadowRoot) return;
+      const testButton = this.shadowRoot.querySelector('.test-button');
+      if (testButton) {
+        testButton.removeEventListener('click', this._boundTestAction);
+      }
+      const runTestButton = this.shadowRoot.querySelector('.run-this-test-button');
+      if (runTestButton) {
+        runTestButton.removeEventListener('click', this._boundRunTest);
+      }
     }
 
     testAction() {
-      this.status = this.status === 'OK' ? 'TESTING' : 'OK';
-      this.updateUI();
+      this.state.currentStatus = this.state.currentStatus === 'OK' ? 'TESTING' : 'OK';
+      if (typeof this.updateUI === 'function') {
+        this.updateUI();
+      } else if (typeof this.render === 'function' && this.shadowRoot) { // Assuming render is the template method name
+        this.shadowRoot.innerHTML = this.render();
+      } else if (typeof this.template === 'function' && this.shadowRoot) { // Fallback if template is used
+        this.shadowRoot.innerHTML = this.template();
+      }
+      this.attachEventHandlers(); // Re-attach listeners
     }
 
-    template() {
+    async runTest() {
+      console.log('[TestElement] Starting test...');
+      const initialStatus = this.state.currentStatus;
+      this.testAction(); // Call the existing action to change status
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      if (this.state.currentStatus !== initialStatus) {
+        this.state.testResult = { success: true, message: `Test action successfully changed status from ${initialStatus} to ${this.state.currentStatus}.` };
+      } else {
+        this.state.testResult = { success: false, message: `Test action failed to change status from ${initialStatus}.` };
+      }
+
+      console.log(`[TestElement] Test result: ${this.state.testResult.message}`);
+
+      if (typeof this.updateUI === 'function') {
+        this.updateUI();
+      } else if (typeof this.render === 'function' && this.shadowRoot) { // Assuming render is the template method name
+        this.shadowRoot.innerHTML = this.render();
+      } else if (typeof this.template === 'function' && this.shadowRoot) { // Fallback if template is used
+        this.shadowRoot.innerHTML = this.template();
+      }
+      this.attachEventHandlers(); // Re-attach listeners
+
+      return this.state.testResult;
+    }
+
+    // Assuming the main render method is `template` as per original code, renaming to `render` for consistency with MinimalBaseClass
+    render() {
+      const testResultStatusClass = this.state.testResult.success === true
+        ? 'success'
+        : this.state.testResult.success === false
+          ? 'failure'
+          : 'not-run';
+      const currentStatusClass = this.getStatusClass(); // Use currentStatus for the main status display
+
       return `
         <div class="test-element-container">
           <div class="header">
@@ -33,12 +123,20 @@ export function TestElementBuilder(ElevateElement) {
             </slot>
           </div>
           <div class="content">
+            <p>Current Status: <span class="status ${currentStatusClass}">${this.state.currentStatus}</span></p>
             <slot></slot>
           </div>
           <div class="footer">
             <slot name="footer">
-              <button class="test-button">Run Test</button>
+              <button class="test-button">Toggle Status</button>
+              <button class="run-this-test-button" type="button">Run This Test</button>
             </slot>
+          </div>
+          <div class="test-result">
+            <h4>Test Result:</h4>
+            <p class="status-message ${testResultStatusClass}">
+              ${this.state.testResult.message}
+            </p>
           </div>
         </div>
       `;
@@ -46,6 +144,7 @@ export function TestElementBuilder(ElevateElement) {
 
     styles() {
       // CSS variables are now included by BaseComponentUtils
+      // Added test-result styles
       return `
         .test-element-container {
           padding: var(--space-lg);
@@ -82,10 +181,11 @@ export function TestElementBuilder(ElevateElement) {
         }
         
         .status {
-          margin: var(--space-md) 0;
-          padding: var(--space-md);
+          /* margin: var(--space-md) 0; */ /* Adjusted to be inline */
+          padding: 0.2rem 0.5rem; /* Smaller padding for inline status */
           border-radius: var(--radius-sm);
           font-weight: var(--weight-medium);
+          display: inline-block; /* For inline display with background */
         }
         
         .status.ok {
@@ -112,11 +212,10 @@ export function TestElementBuilder(ElevateElement) {
           border: 1px solid rgba(10, 132, 255, 0.2);
         }
         
-        .test-button {
+        .test-button, .run-this-test-button { /* Shared style for buttons */
           position: relative;
           display: inline-block;
           padding: var(--space-xs) var(--space-md);
-          background-color: var(--color-primary);
           color: var(--color-on-primary);
           border: none;
           border-radius: var(--radius-md);
@@ -130,7 +229,16 @@ export function TestElementBuilder(ElevateElement) {
                       transform var(--duration-short) var(--easing-standard);
           box-shadow: var(--elevation-1);
           margin-top: var(--space-md);
+          margin-right: var(--space-sm); /* Space between buttons */
           z-index: 1;
+        }
+
+        .test-button { /* Specific color for original button */
+          background-color: var(--color-primary);
+        }
+        .run-this-test-button { /* Specific color for new test button */
+           background-color: var(--color-secondary, #03dac6); /* Default if secondary is not set */
+           color: var(--color-on-secondary, white); /* Default if on-secondary is not set */
         }
         
         .test-button:hover {
@@ -138,17 +246,29 @@ export function TestElementBuilder(ElevateElement) {
           box-shadow: var(--elevation-2);
           transform: translateY(-2px);
         }
+        .run-this-test-button:hover {
+          background-color: var(--color-secondary-dark, #018786); /* Default if secondary-dark is not set */
+          box-shadow: var(--elevation-2);
+          transform: translateY(-2px);
+        }
         
-        .test-button:active {
+        .test-button:active, .run-this-test-button:active {
           transform: translateY(0);
           box-shadow: var(--elevation-1);
         }
+
+        .test-result { margin-top: 10px; padding: 10px; border: 1px solid #eee; border-radius: 5px;}
+        .test-result h4 { margin-top: 0; margin-bottom: 5px; }
+        .status-message { padding: 5px; border-radius: 3px; }
+        .status-message.success { color: green; background-color: #e6ffe6; border: 1px solid green;}
+        .status-message.failure { color: red; background-color: #ffe6e6; border: 1px solid red;}
+        .status-message.not-run { color: orange; background-color: #fff0e0; border: 1px solid orange;}
       `;
     }
     
     // Helper methods
     getStatusClass() {
-      switch(this.status) {
+      switch(this.state.currentStatus) { // Use this.state.currentStatus
         case 'OK': return 'ok';
         case 'TESTING': return 'testing';
         case 'WARNING': return 'warning';

--- a/elevateElement/components/tests/ChannelSyncTestElement.js
+++ b/elevateElement/components/tests/ChannelSyncTestElement.js
@@ -34,20 +34,17 @@ export function ChannelSyncTestElementBuilder() {
       
       // Subscribe to state changes
       this._unsubscribe = StateManager.subscribe('channelCount', (newValue) => {
-        this.globalCount = newValue; // This directly mutates a property
-        this.updateUI(); // this.updateUI will re-render and re-attach listeners
+        this.globalCount = newValue;
+        this.updateUI();
+        this.addEventListeners(); // Re-attach after render
       });
     }
 
     connectedCallback() {
       super.connectedCallback();
       console.log('[ChannelSyncTestElement] connected');
-      
-      // Initial UI render and event listener setup
-      // updateUI calls addEventListeners, so just one call is fine.
-      this.updateUI();
-      
-      // Open the BroadcastChannel
+      this.updateUI(); // Initial render
+      this.addEventListeners(); // Attach listeners
       this.openChannel();
     }
 
@@ -70,8 +67,7 @@ export function ChannelSyncTestElementBuilder() {
     
     // Add event listeners manually
     addEventListeners() {
-      // First render the UI to create the elements
-      this.updateUI();
+      if (!this.shadowRoot) return; // Guard against no shadowRoot
       
       // Then attach event listeners using proper binding
       const incrementButton = this.shadowRoot.querySelector('.increment-button');
@@ -116,10 +112,11 @@ export function ChannelSyncTestElementBuilder() {
 
     async handleRunThisTest() {
       try {
-        await this.runTest(); // runTest will update state.testResult and call updateUI
+        await this.runTest();
       } catch (e) {
         this.state.testResult = { success: false, message: `Test execution error: ${e.message}` };
-        this.updateUI(); // Ensure UI updates on direct error
+        this.updateUI();
+        this.addEventListeners(); // Re-attach
         console.error('[ChannelSyncTestElement] Error during runTest from button:', e);
       }
     }
@@ -157,9 +154,8 @@ export function ChannelSyncTestElementBuilder() {
     
     // Update UI method
     updateUI() {
+      if (!this.shadowRoot) return; // Guard against no shadowRoot
       this.shadowRoot.innerHTML = this.render();
-      // Re-attach event listeners after shadow DOM update
-      this.addEventListeners();
     }
 
     render() {
@@ -292,8 +288,9 @@ export function ChannelSyncTestElementBuilder() {
         success: allTestsPassed,
         message: messages.join(' | ')
       };
-      this.state.testResult = result; // Update state
-      this.updateUI(); // Manually trigger UI update
+      this.state.testResult = result;
+      this.updateUI();
+      this.addEventListeners(); // Re-attach after render
 
       return result;
     }

--- a/elevateElement/components/tests/PostTestElement.js
+++ b/elevateElement/components/tests/PostTestElement.js
@@ -1,0 +1,241 @@
+// elevateElement/components/PostTestElement.js
+
+export function PostTestElementBuilder(ElevateElementClass) {
+    class PostTestElement extends ElevateElementClass {
+      constructor() {
+        super('post-test-element');
+
+        this.state = {
+          response: null,
+          loading: false,
+          error: '',
+          testResult: { success: null, message: 'Test not run yet.' }
+        };
+
+        this._boundSendPost = (e) => this.sendPost(e);
+        this._boundHandleRunThisTest = this.handleRunThisTest.bind(this);
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        console.log('[PostTestElement] connected');
+        if (this.shadowRoot && typeof this.render === 'function') {
+          this.shadowRoot.innerHTML = this.render();
+        }
+        this.attachEventHandlers();
+      }
+
+      disconnectedCallback() {
+        console.log('[PostTestElement] disconnected');
+        this.removeEventListeners();
+        super.disconnectedCallback && super.disconnectedCallback();
+      }
+
+      attachEventHandlers() {
+        if (!this.shadowRoot) return;
+        const postButton = this.shadowRoot.querySelector('.post-button');
+        const runTestButton = this.shadowRoot.querySelector('.run-this-test-button');
+
+        if (postButton) {
+          postButton.removeEventListener('click', this._boundSendPost);
+          postButton.addEventListener('click', this._boundSendPost);
+        }
+        if (runTestButton) {
+          runTestButton.removeEventListener('click', this._boundHandleRunThisTest);
+          runTestButton.addEventListener('click', this._boundHandleRunThisTest);
+        }
+      }
+
+      removeEventListeners() {
+        if (!this.shadowRoot) return;
+        const postButton = this.shadowRoot.querySelector('.post-button');
+        const runTestButton = this.shadowRoot.querySelector('.run-this-test-button');
+
+        if (postButton) {
+          postButton.removeEventListener('click', this._boundSendPost);
+        }
+        if (runTestButton) {
+          runTestButton.removeEventListener('click', this._boundHandleRunThisTest);
+        }
+      }
+
+      async handleRunThisTest() {
+        try {
+          await this.runTest();
+        } catch (e) {
+          this.setState({ testResult: { success: false, message: `Test execution error: ${e.message}` } });
+          this.attachEventHandlers(); // Re-attach listeners
+          console.error('[PostTestElement] Error during runTest from button:', e);
+        }
+      }
+
+      async sendPost(e) {
+        console.log('[PostTestElement] Sending POST request...');
+        this.setState({ loading: true, error: '', response: null });
+        this.attachEventHandlers(); // Re-attach as DOM might change (e.g. loading indicator)
+
+        try {
+          const payload = {
+            title: 'foo',
+            body: 'bar',
+            userId: 1
+          };
+
+          const response = await fetch('https://jsonplaceholder.typicode.com/posts', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Request failed: ${response.status} ${response.statusText}\n${errorText}`);
+          }
+
+          const data = await response.json();
+          console.log('[PostTestElement] POST response:', data);
+          // Store raw data object for easier assertion, and stringify for display
+          this.rawResponse = data; // Store for assertion
+          this.setState({ response: JSON.stringify(data, null, 2), loading: false, error: '' });
+          this.attachEventHandlers();
+        } catch (err) {
+          console.error('[PostTestElement] POST error:', err);
+          this.rawResponse = null; // Clear previous response on error
+          this.setState({ error: err.message, loading: false, response: null });
+          this.attachEventHandlers();
+        }
+      }
+
+      async runTest() {
+        console.log('[PostTestElement] Starting test...');
+        // Resetting testResult before running the test to clear previous results from UI
+        this.setState({ testResult: { success: null, message: 'Test running...' } });
+        this.attachEventHandlers();
+        await new Promise(resolve => setTimeout(resolve, 0)); // Allow DOM to update if setState is async
+
+        await this.sendPost(); // Call sendPost and wait for it to complete
+
+        let testResult = { success: false, message: '' };
+
+        if (this.state.loading) {
+          testResult.message = 'Assertion failed: loading is still true after sendPost.';
+          console.error('[PostTestElement] Assertion Failed:', testResult.message);
+          // No need for this.update or this.requestUpdate if setState handles rendering
+          // and attachEventHandlers is called after setState.
+          this.setState({ testResult: testResult });
+          this.attachEventHandlers();
+          return testResult;
+        }
+
+        if (this.state.error) {
+          testResult.message = `Assertion failed: Post operation resulted in an error: ${this.state.error}`;
+          console.error('[PostTestElement] Assertion Failed:', testResult.message);
+        } else if (this.rawResponse) {
+          const responseData = this.rawResponse;
+
+          if (responseData.title === 'foo' && responseData.hasOwnProperty('id')) {
+            if (!this.state.error && !this.state.loading) {
+              testResult.success = true;
+              testResult.message = 'Post test passed: Response data is correct, error is empty, and loading is false.';
+              console.log('[PostTestElement] Assertion Passed:', testResult.message);
+            } else {
+              testResult.message = `Assertion failed: Post conditions not met. Error: "${this.state.error}", Loading: ${this.state.loading}`;
+              console.error('[PostTestElement] Assertion Failed:', testResult.message);
+            }
+          } else {
+            testResult.message = `Assertion failed: Response data incorrect. Title: "${responseData.title}", ID present: ${responseData.hasOwnProperty('id')}`;
+            console.error('[PostTestElement] Assertion Failed:', testResult.message);
+          }
+        } else {
+          testResult.message = 'Assertion failed: No response data found after post operation and no error reported.';
+          console.error('[PostTestElement] Assertion Failed:', testResult.message);
+        }
+
+        this.setState({ testResult: testResult });
+        this.attachEventHandlers();
+        return testResult;
+      }
+
+      render() {
+        const testResultStatusClass = this.state.testResult.success === true
+          ? 'success'
+          : this.state.testResult.success === false
+            ? 'failure'
+            : 'not-run';
+
+        return `
+          <style>
+            :host {
+              display: block;
+              font-family: sans-serif;
+              padding: 1rem;
+            }
+            button { /* General button styling */
+              padding: 0.5rem 1rem;
+              border: none;
+              border-radius: 5px;
+              cursor: pointer;
+              margin-bottom: 1rem;
+              margin-right: 0.5rem; /* Space between buttons */
+              color: white; /* Default text color for buttons */
+            }
+            .post-button {
+              background: var(--primary-color, #6200ea);
+            }
+            .run-this-test-button {
+              background: var(--secondary-color, #03dac6); /* Example color */
+            }
+            pre {
+              background: #f5f5f5;
+              padding: 1rem;
+              border-radius: 5px;
+              overflow: auto;
+              border: 1px solid #ddd;
+            }
+            p.error {
+              color: var(--error-color, red);
+            }
+            .test-result {
+              margin-top: 10px;
+              padding: 10px;
+              border: 1px solid #eee;
+              border-radius: 5px;
+            }
+            .test-result h4 { margin-top: 0; margin-bottom: 5px; }
+            .status-message { padding: 5px; border-radius: 3px; }
+            .status-message.success { color: green; background-color: #e6ffe6; border: 1px solid green; }
+            .status-message.failure { color: red; background-color: #ffe6e6; border: 1px solid red;}
+            .status-message.not-run { color: orange; background-color: #fff0e0; border: 1px solid orange;}
+          </style>
+
+          <div>
+            <button class="post-button">Send Test Post</button>
+            <button class="run-this-test-button">Run This Test</button>
+
+            ${this.state.loading
+              ? `<p>Loading...</p>`
+              : this.state.error
+                ? `<p class="error">${this.state.error}</p>`
+                : this.state.response
+                  ? `<pre>${this.state.response}</pre>`
+                  : `<p>No response yet.</p>`}
+
+            <div class="test-result">
+              <h4>Test Result:</h4>
+              <p class="status-message ${testResultStatusClass}">
+                ${this.state.testResult.message}
+              </p>
+            </div>
+          </div>
+        `;
+      }
+    }
+
+    if (!customElements.get('post-test-element')) {
+      customElements.define('post-test-element', PostTestElement);
+      console.log('[PostTestElement] Custom element defined by PostTestElementBuilder.');
+    }
+    return PostTestElement;
+  }

--- a/elevateElement/components/tests/RouterTestElement.js
+++ b/elevateElement/components/tests/RouterTestElement.js
@@ -1,0 +1,227 @@
+// elevateElement/components/tests/RouterTestElement.js
+
+// Assuming MinimalBaseClass will be passed from Tests.js for now
+// It needs connectedCallback, disconnectedCallback, setState, render, shadowRoot
+
+export function RouterTestElementBuilder(ElevateElementClass) {
+  class RouterTestElement extends ElevateElementClass {
+    constructor() {
+      super('router-test-element'); // Call super if ElevateElementClass expects it
+
+      this.state = {
+        currentPathDisplay: '', // To show path from router's perspective
+        lastNavigationPath: '', // Path received from onRouteChange
+        lastNavigationParams: {}, // Params received from onRouteChange
+        testResult: { success: null, message: 'Test not run yet.' }
+      };
+
+      this._routerSubscription = null;
+      this._boundHandleRunTest = this.runTest.bind(this);
+      this._boundNavigateToHome = () => this.navigateToPath('/');
+      this._boundNavigateToTests = () => this.navigateToPath('/tests');
+      // Add a test route that might not exist to test 404 or specific handling if desired
+      this._boundNavigateToNonExistent = () => this.navigateToPath('/non-existent-test-route');
+    }
+
+    connectedCallback() {
+      super.connectedCallback && super.connectedCallback(); // Call if base class has it
+      console.log('[RouterTestElement] connected');
+
+      if (window.ElevateRouter && typeof window.ElevateRouter.onRouteChange === 'function') {
+        this._routerSubscription = window.ElevateRouter.onRouteChange((path, params) => {
+          console.log('[RouterTestElement] onRouteChange:', path, params);
+          this.setState({
+            lastNavigationPath: path,
+            lastNavigationParams: params || {}
+          });
+          this.updateCurrentPathDisplay(); // Update display on route change
+          this.attachEventHandlers(); // Re-attach as setState might re-render
+        });
+      } else {
+        console.error('[RouterTestElement] ElevateRouter not found or onRouteChange is not available.');
+        this.setState({ testResult: { success: false, message: 'ElevateRouter not available for testing.' } });
+      }
+
+      this.updateCurrentPathDisplay(); // Initial path display
+
+      // Initial render and event attachment
+      if (this.shadowRoot && typeof this.render === 'function') {
+        this.shadowRoot.innerHTML = this.render();
+      }
+      this.attachEventHandlers();
+    }
+
+    disconnectedCallback() {
+      if (this._routerSubscription && typeof this._routerSubscription === 'function') {
+        this._routerSubscription(); // Unsubscribe
+      }
+      this.removeEventListeners && this.removeEventListeners();
+      super.disconnectedCallback && super.disconnectedCallback();
+      console.log('[RouterTestElement] disconnected');
+    }
+
+    updateCurrentPathDisplay() {
+      if (window.ElevateRouter && typeof window.ElevateRouter.parsePath === 'function') {
+        this.setState({ currentPathDisplay: window.ElevateRouter.parsePath() });
+        // No attachEventHandlers here as this is often called from within other handlers or connectedCallback
+        // which already manage re-attachment. Avoid potential loops if setState itself doesn't re-render.
+        // If setState *does* re-render, the caller of updateCurrentPathDisplay should handle re-attaching.
+      }
+    }
+
+    navigateToPath(path) {
+      if (window.ElevateRouter && typeof window.ElevateRouter.navigate === 'function') {
+        console.log(`[RouterTestElement] Navigating to: ${path}`);
+        window.ElevateRouter.navigate(path);
+        // onRouteChange will update the state.currentPathDisplay via its own call to updateCurrentPathDisplay
+      } else {
+        this.setState({ testResult: { success: false, message: 'ElevateRouter.navigate not available.' } });
+        this.attachEventHandlers(); // Re-attach if state change causes re-render
+      }
+    }
+
+    attachEventHandlers() {
+      if (!this.shadowRoot) return;
+
+      const homeBtn = this.shadowRoot.querySelector('.navigate-home-btn');
+      if (homeBtn) {
+        homeBtn.removeEventListener('click', this._boundNavigateToHome);
+        homeBtn.addEventListener('click', this._boundNavigateToHome);
+      }
+
+      const testsBtn = this.shadowRoot.querySelector('.navigate-tests-btn');
+      if (testsBtn) {
+        testsBtn.removeEventListener('click', this._boundNavigateToTests);
+        testsBtn.addEventListener('click', this._boundNavigateToTests);
+      }
+
+      const nonExistentBtn = this.shadowRoot.querySelector('.navigate-non-existent-btn');
+      if(nonExistentBtn) {
+        nonExistentBtn.removeEventListener('click', this._boundNavigateToNonExistent);
+        nonExistentBtn.addEventListener('click', this._boundNavigateToNonExistent);
+      }
+
+      const runTestBtn = this.shadowRoot.querySelector('.run-this-test-button');
+      if (runTestBtn) {
+        runTestBtn.removeEventListener('click', this._boundHandleRunTest);
+        runTestBtn.addEventListener('click', this._boundHandleRunTest);
+      }
+    }
+
+    removeEventListeners() {
+      if (!this.shadowRoot) return;
+      const homeBtn = this.shadowRoot.querySelector('.navigate-home-btn');
+      if (homeBtn) homeBtn.removeEventListener('click', this._boundNavigateToHome);
+      const testsBtn = this.shadowRoot.querySelector('.navigate-tests-btn');
+      if (testsBtn) testsBtn.removeEventListener('click', this._boundNavigateToTests);
+      const nonExistentBtn = this.shadowRoot.querySelector('.navigate-non-existent-btn');
+      if(nonExistentBtn) nonExistentBtn.removeEventListener('click', this._boundNavigateToNonExistent);
+      const runTestBtn = this.shadowRoot.querySelector('.run-this-test-button');
+      if (runTestBtn) runTestBtn.removeEventListener('click', this._boundHandleRunTest);
+    }
+
+    async runTest() {
+      console.log('[RouterTestElement] Starting test...');
+      if (!window.ElevateRouter || typeof window.ElevateRouter.navigate !== 'function' || typeof window.ElevateRouter.parsePath !== 'function') {
+        this.setState({ testResult: { success: false, message: 'ElevateRouter or its methods not available.' } });
+        if (typeof this.render === 'function' && this.shadowRoot) this.shadowRoot.innerHTML = this.render();
+        this.attachEventHandlers();
+        return;
+      }
+
+      let allTestsPassed = true;
+      let messages = [];
+      const originalPath = window.ElevateRouter.parsePath();
+
+      // Test 1: Navigate to / (Home)
+      this.navigateToPath('/');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      if (this.state.lastNavigationPath === '/' && window.ElevateRouter.parsePath() === '/') {
+        messages.push('Navigate to /: OK');
+      } else {
+        allTestsPassed = false;
+        messages.push(`Navigate to /: FAIL (lastNav: ${this.state.lastNavigationPath}, currentPath: ${window.ElevateRouter.parsePath()})`);
+      }
+
+      // Test 2: Navigate to /tests
+      this.navigateToPath('/tests');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      if (this.state.lastNavigationPath === '/tests' && window.ElevateRouter.parsePath() === '/tests') {
+        messages.push('Navigate to /tests: OK');
+      } else {
+        allTestsPassed = false;
+        messages.push(`Navigate to /tests: FAIL (lastNav: ${this.state.lastNavigationPath}, currentPath: ${window.ElevateRouter.parsePath()})`);
+      }
+
+      const nonExistentPath = '/non-existent-test-route';
+      this.navigateToPath(nonExistentPath);
+      await new Promise(resolve => setTimeout(resolve, 100));
+      if (this.state.lastNavigationPath === nonExistentPath) {
+        messages.push(`Attempt to navigate to ${nonExistentPath}: OK (event fired)`);
+      } else {
+        allTestsPassed = false;
+        messages.push(`Attempt to navigate to ${nonExistentPath}: FAIL (event not fired for this path, lastNav: ${this.state.lastNavigationPath})`);
+      }
+
+      if (originalPath !== window.ElevateRouter.parsePath()) {
+         console.log(`[RouterTestElement] Restoring original path to: ${originalPath}`);
+         this.navigateToPath(originalPath);
+         await new Promise(resolve => setTimeout(resolve, 100));
+      }
+
+      this.setState({
+        testResult: { success: allTestsPassed, message: messages.join('; ') }
+      });
+      // setState with MinimalBaseClass calls render, so DOM is new.
+      this.attachEventHandlers(); // Re-attach to new DOM.
+      return this.state.testResult;
+    }
+
+    render() {
+      const testResultStatusClass = this.state.testResult.success === true ? 'success'
+                                  : this.state.testResult.success === false ? 'failure'
+                                  : 'not-run';
+      return \`
+        <style>
+          :host { display: block; padding: 10px; border: 1px solid #eee; margin-bottom:10px; font-family: sans-serif; }
+          button { margin: 5px; padding: 8px 12px; border: none; border-radius: 4px; cursor: pointer; background-color: #007bff; color: white; }
+          button:hover { background-color: #0056b3; }
+          .run-this-test-button { background-color: #28a745; }
+          .run-this-test-button:hover { background-color: #1e7e34; }
+          .path-display { margin-top:10px; padding:10px; background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; }
+          .path-display p { margin: 5px 0; }
+          .test-result { margin-top: 10px; padding: 10px; border: 1px solid #dee2e6; border-radius: 5px;}
+          .test-result h4 { margin-top: 0; margin-bottom: 5px; color: #343a40; }
+          .status-message { padding: 8px; border-radius: 4px; font-weight: bold; }
+          .status-message.success { color: #155724; background-color: #d4edda; border: 1px solid #c3e6cb;}
+          .status-message.failure { color: #721c24; background-color: #f8d7da; border: 1px solid #f5c6cb;}
+          .status-message.not-run { color: #856404; background-color: #fff3cd; border: 1px solid #ffeeba;}
+        </style>
+        <div>
+          <h4>Router Test</h4>
+          <button class="navigate-home-btn">Navigate to Home (/)</button>
+          <button class="navigate-tests-btn">Navigate to Tests (/tests)</button>
+          <button class="navigate-non-existent-btn">Navigate to /non-existent-test-route</button>
+          <button class="run-this-test-button">Run This Test</button>
+          <div class="path-display">
+            <p>Current Path (from Router.parsePath()): <strong>\${this.state.currentPathDisplay}</strong></p>
+            <p>Last Navigated Path (from event): <strong>\${this.state.lastNavigationPath}</strong></p>
+            <p>Last Nav Params: <strong>\${JSON.stringify(this.state.lastNavigationParams)}</strong></p>
+          </div>
+          <div class="test-result">
+            <h4>Test Result:</h4>
+            <p class="status-message \${testResultStatusClass}">
+              \${this.state.testResult.message}
+            </p>
+          </div>
+        </div>
+      \`;
+    }
+  }
+
+  if (!customElements.get('router-test-element')) {
+    customElements.define('router-test-element', RouterTestElement);
+    console.log('[RouterTestElement] Custom element defined by RouterTestElementBuilder.');
+  }
+  return RouterTestElement;
+}


### PR DESCRIPTION
This commit significantly refactors and enhances the test suite and the manual test page (`/tests`).

Key improvements include:

1.  **Manual Test Page (`Tests.js`):**
    *   Ensured all test component builders are correctly imported and invoked, using a placeholder base class for broader compatibility during testing.
    *   Updated component tracking lists to accurately reflect all available test elements.
    *   Enhanced usability by displaying the initialization status of test components directly on the page.
    *   Upgraded the "Run All Tests" functionality to aggregate results from individual components, providing a clear pass/fail summary.

2.  **Individual Test Component Refactoring:**
    *   Standardized most test components (including TestElement, ErrorTestElement, ChannelSyncTestElement, PostTestElement, RetryErrorElement, EventBridgeElement, ManualEventElement, LayoutTestElement, ConfigDisplayElement) to:
        *   Reliably implement a `runTest()` method with assertions.
        *   Feature a ".run-this-test-button" for manual execution.
        *   Clearly display individual pass/fail status within their UI.
        *   Employ robust manual event listener management (`attachEventHandlers`, `removeEventListeners`), removing reliance on potentially incompatible base class `events()` maps. This ensures listeners are active even after internal DOM updates.
    *   Addressed various bugs, including event listener leaks and improper UI update sequences.

3.  **New Test Coverage:**
    *   Introduced `RouterTestElement.js` to test fundamental client-side routing features, such as programmatic navigation and route change event handling. This new component is integrated into the manual test page.

4.  **Code Hygiene:**
    *   Corrected the filename of `PostTestElement .js` to `PostTestElement.js` and updated all corresponding imports.

These changes collectively make the test suite more robust, easier to use for manual testing, and provide better feedback on the health of core application features.